### PR TITLE
cmake: add options to build SHARED/STATIC libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ set(CMAKE_CXX_STANDARD 17)
 
 find_package(PkgConfig REQUIRED)
 
+option(BUILD_SHARED "build shared library" OFF)
+option(BUILD_STATIC "build static library" ON)
+
 # In the future, we should create a better mechanism to change this.
 if (${IPCGULL_STUB})
     set(IPCGULL_BACKEND_SRC src/server_stub.cpp)
@@ -16,16 +19,37 @@ else ()
     set(IPCGULL_BACKEND_LIBRARIES ${GIO_LIBRARIES} ${GLIB_LIBRARIES})
 endif ()
 
+MESSAGE(STATUS "  Build shared library:          " ${BUILD_SHARED})
+MESSAGE(STATUS "  Build static library:          " ${BUILD_STATIC})
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 include_directories(src/include/ ${IPCGULL_BACKEND_INCLUDE})
-add_library(ipcgull
-        src/function.cpp
-        src/property.cpp
-        src/signal.cpp
-        src/interface.cpp
-        src/node.cpp
-        src/exception.cpp
-        ${IPCGULL_BACKEND_SRC})
+
+set(ipcgull_src
+    src/function.cpp
+    src/property.cpp
+    src/signal.cpp
+    src/interface.cpp
+    src/node.cpp
+    src/exception.cpp
+    ${IPCGULL_BACKEND_SRC}
+)
+
+add_library(ipcgull OBJECT ${ipcgull_src})
 target_link_libraries(ipcgull ${IPCGULL_BACKEND_LIBRARIES})
+
+if (BUILD_SHARED)
+    add_library(ipcgull_shared SHARED $<TARGET_OBJECTS:ipcgull>)
+    target_link_libraries(ipcgull_shared PUBLIC $<TARGET_PROPERTY:ipcgull,LINK_LIBRARIES>)
+    set_target_properties(ipcgull_shared PROPERTIES OUTPUT_NAME ipcgull)
+endif()
+
+if (BUILD_STATIC)
+    add_library(ipcgull_static STATIC $<TARGET_OBJECTS:ipcgull>)
+    target_link_libraries(ipcgull_static PUBLIC $<TARGET_PROPERTY:ipcgull,LINK_LIBRARIES>)
+    set_target_properties(ipcgull_static PROPERTIES OUTPUT_NAME ipcgull)
+endif()
 
 if (${BUILD_TESTS})
     add_subdirectory(tests/server_test)


### PR DESCRIPTION
We need an ability to build/use shared version of the library for fedora.

See https://bugzilla.redhat.com/show_bug.cgi?id=2203090